### PR TITLE
[OSAB] Task 3: Add 0-axis lines to scatterplots

### DIFF
--- a/bashplotlib/scatterplot.py
+++ b/bashplotlib/scatterplot.py
@@ -35,17 +35,43 @@ def _plot_scatter(xs, ys, size, pch, colour, title, cs):
         print(box_text(title, 2 * (len(get_scale(xs, False, size)) + 1)))
 
     print("-" * (2 * (len(get_scale(xs, False, size)) + 2)))
+
+    # Iterate through all squares in the graph. For each square,
+    # search through all the co-ordinates that we need to plot, and see
+    # if any of them should be plotted on the current graph square
+    # being considered.
     for y in get_scale(ys, True, size):
         print("|", end=' ')
         for x in get_scale(xs, False, size):
-            point = " "
+            found_coord = False
             for (i, (xp, yp)) in enumerate(zip(xs, ys)):
                 if xp <= x and yp >= y and (xp, yp) not in plotted:
-                    point = pch
+                    found_coord = True
                     plotted.add((xp, yp))
                     if cs:
                         colour = cs[i]
-            printcolour(point + " ", True, colour)
+
+            # If we did find a co-ordinate that needs plotting, make sure we
+            # plot it and not a 0-axis.
+            if found_coord:
+                char_to_plot = pch
+            else:
+                # The `get_scale` function always returns a scale that
+                # includes a 0.0 point, if the co-ordinates it is given cross
+                # 0 (i.e. include both negative and positive numbers).
+                #
+                # This means that we know that these conditions will trigger
+                # at some point if our co-ordinates cross 0.
+                if x == 0.0 and y == 0.0:
+                    char_to_plot = "o"
+                elif x == 0.0:
+                    char_to_plot = "|"
+                elif y == 0.0:
+                    char_to_plot = "-"
+                else:
+                    char_to_plot = " "
+
+            printcolour(char_to_plot + " ", True, colour)
         print(" |")
     print("-" * (2 * (len(get_scale(xs, False, size)) + 2)))
 


### PR DESCRIPTION
This is one way to solve Task 3 in https://robertheaton.com/2019/04/14/open-source-for-advanced-beginners-1-bashplotlib/.

### Test:

I ran:

```python
from bashplotlib.scatterplot import plot_scatter

x_coords = [-10,-4,10,20,30]
y_coords = [-10,-2,18,20,30]
width = 10
char = 'x'
color = 'default'
title = 'Test Title'

plot_scatter(
    None,
    x_coords,
    y_coords,
    width,
    char,
    color,
    title)
```

and got:

<img width="175" alt="bpl-zero-axes-example" src="https://user-images.githubusercontent.com/1565857/55292889-e8622980-53a4-11e9-8672-b0b5e57b224b.png">
