### PR TITLE
adding + signs to the title corners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.history
 *.pyc
 env
 *.txt

--- a/bashplotlib/utils/helpers.py
+++ b/bashplotlib/utils/helpers.py
@@ -80,7 +80,7 @@ def box_text(text, width, offset=0):
     """
     Return text inside an ascii textbox
     """
-    box = " " * offset + "-" * (width+2) + "\n"
+    box = " " * offset + "+" + "-" * (width) + "+" + "\n"
     box += " " * offset + "|" + text.center(width) + "|" + "\n"
-    box += " " * offset + "-" * (width+2)
+    box += " " * offset +  "+" + "-" * (width) + "+" 
     return box


### PR DESCRIPTION
Following OSAB Tutorial. Task 1, adding + signs to the corners of the title. I also added .history to the gitignore to ignore that in my VSCode. 